### PR TITLE
Avoid redirect loop

### DIFF
--- a/firefox/lib/main.js
+++ b/firefox/lib/main.js
@@ -10,6 +10,10 @@ function listener(event) {
     // we don't want to check isPrivate() for non-amazon, so just exit here
     return;
   }
+  if(event.subject.referrer.spec.match(/.*:\/\/smile\.amazon\.com\/.*/)) {
+    // prevent redirect loop for non-logged in users
+    return;
+  }
   if(isPrivate(getDispatchingWindow(event))) {
     return;
   }


### PR DESCRIPTION
Don't send request back to smile if it was redirected from smile to begin with because user isn't authenticated.
